### PR TITLE
Use radio buttons for transformation model selection

### DIFF
--- a/affinder/affinder.py
+++ b/affinder/affinder.py
@@ -86,6 +86,7 @@ def close_affinder(layers, callback):
         call_button='Start',
         layout='vertical',
         output={'mode': 'w'},
+        model={'widget_type': 'RadioButtons'},
         viewer={'visible': False, 'label': ' '},
         )
 def start_affinder(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ napari-plugin-engine>=0.1.9
 napari>=0.4.3
 numpy
 scikit-image
-magicgui>=0.2.5,!=0.2.7
+magicgui>=0.2.9
 napari
 toolz


### PR DESCRIPTION
**Don't merge before magicgui 0.2.9 is released!**

This changes the UI for the model selection to a radio button, which is more intuitive for a small set of choices that one always wants to see.

- use radio buttons for the model selection
- Require magicgui 0.2.9
