### PR TITLE
Add test based on basic example

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install setuptools tox tox-gh-actions
+          python -m pip install .[testing]
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox

--- a/affinder/_tests/test_affinder.py
+++ b/affinder/_tests/test_affinder.py
@@ -7,7 +7,7 @@ def test_basic(make_napari_viewer, napari_plugin_manager):
     image0 = data.camera()
     image1 = transform.rotate(image0[100:, 32:496], 60)
 
-    napari_plugin_manager.register(affinder, name='affinder')
+    napari_plugin_manager.register(affinder.plugin, name='affinder')
     viewer = make_napari_viewer()
 
     l0 = viewer.add_image(image0, colormap='green', blending='additive')

--- a/affinder/_tests/test_affinder.py
+++ b/affinder/_tests/test_affinder.py
@@ -6,7 +6,7 @@ def test_basic(make_napari_viewer):
     image0 = data.camera()
     image1 = transform.rotate(image0[100:, 32:496], 60)
 
-    viewer = make_napari_viewer()
+    viewer = make_napari_viewer(block_plugin_discovery=False)
 
     l0 = viewer.add_image(image0, colormap='green', blending='additive')
     l1 = viewer.add_image(image1, colormap='magenta', blending='additive')

--- a/affinder/_tests/test_affinder.py
+++ b/affinder/_tests/test_affinder.py
@@ -1,3 +1,4 @@
+import affinder
 from skimage import data, transform
 import numpy as np
 
@@ -6,7 +7,7 @@ def test_basic(make_napari_viewer, napari_plugin_manager):
     image0 = data.camera()
     image1 = transform.rotate(image0[100:, 32:496], 60)
 
-    napari_plugin_manager.register('affinder', name='affinder')
+    napari_plugin_manager.register(affinder, name='affinder')
     viewer = make_napari_viewer()
 
     l0 = viewer.add_image(image0, colormap='green', blending='additive')

--- a/affinder/_tests/test_affinder.py
+++ b/affinder/_tests/test_affinder.py
@@ -1,4 +1,4 @@
-import affinder
+import affinder.plugin
 from skimage import data, transform
 import numpy as np
 

--- a/affinder/_tests/test_affinder.py
+++ b/affinder/_tests/test_affinder.py
@@ -2,11 +2,12 @@ from skimage import data, transform
 import numpy as np
 
 
-def test_basic(make_napari_viewer):
+def test_basic(make_napari_viewer, napari_plugin_manager):
     image0 = data.camera()
     image1 = transform.rotate(image0[100:, 32:496], 60)
 
-    viewer = make_napari_viewer(block_plugin_discovery=False)
+    napari_plugin_manager.register('affinder', name='affinder')
+    viewer = make_napari_viewer()
 
     l0 = viewer.add_image(image0, colormap='green', blending='additive')
     l1 = viewer.add_image(image1, colormap='magenta', blending='additive')

--- a/affinder/_tests/test_affinder.py
+++ b/affinder/_tests/test_affinder.py
@@ -1,2 +1,33 @@
-def test_dummy():
-    pass
+from skimage import data, transform
+import numpy as np
+
+
+def test_basic(make_napari_viewer):
+    image0 = data.camera()
+    image1 = transform.rotate(image0[100:, 32:496], 60)
+
+    viewer = make_napari_viewer()
+
+    l0 = viewer.add_image(image0, colormap='green', blending='additive')
+    l1 = viewer.add_image(image1, colormap='magenta', blending='additive')
+
+    qtwidget, widget = viewer.window.add_plugin_dock_widget(
+            'affinder', 'start_affinder'
+            )
+    widget.reference.bind(l0)
+    widget.moving.bind(l1)
+    widget()
+
+    viewer.layers['image0_pts'].data = np.array([[148.19396647, 234.87779732],
+                                                 [484.56804381, 240.55720892],
+                                                 [474.77521025, 385.88403205]])
+    viewer.layers['image1_pts'].data = np.array([[150.02534429, 80.65355322],
+                                                 [314.75696913, 375.13825634],
+                                                 [184.33085012, 439.81718637]])
+    actual = np.asarray(l1.affine)
+    expected = np.array(  # yapf: ignore
+            [[0.50221294, 0.86131375, 3.38128256],
+             [-0.86478707, 0.50303866, 324.04591946],
+             [0., 0., 1.]])
+
+    np.testing.assert_allclose(actual, expected)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,10 @@ packages = find:
 setup_requires = setuptools_scm
 install_requires =
     napari-plugin-engine>=0.1.9
-    napari>=0.4.3
+    napari>=0.4.12
     numpy
     scikit-image
-    magicgui>=0.2.5,!=0.2.7
+    magicgui>=0.3.3
     napari
     toolz
 python_requires = >=3.7
@@ -37,3 +37,11 @@ python_requires = >=3.7
 [options.entry_points]
 console_scripts = affinder=affinder.main:main
 napari.plugin = affinder = affinder.plugin
+
+[options.extras_require]
+testing =
+    coverage
+    pytest
+    pytest-cov
+    pytest-qt
+    scikit-image[data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,3 +45,4 @@ testing =
     pytest-cov
     pytest-qt
     scikit-image[data]
+    napari[pyqt5]

--- a/tox.ini
+++ b/tox.ini
@@ -29,4 +29,6 @@ deps =
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-xvfb ; sys_platform == 'linux'
+    pytest-qt
+    scikit-image[data]
 commands = pytest -v --color=yes --cov=affinder --cov-report=xml

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,5 @@ deps =
     pytest-xvfb ; sys_platform == 'linux'
     pytest-qt
     scikit-image[data]
+    napari[pyqt5]
 commands = pytest -v --color=yes --cov=affinder --cov-report=xml


### PR DESCRIPTION
Note: this isn't currently working, as the viewer fails to find the affinder plugin. The error message is "Plugin affinder doesn't provide any dock widgets", but I checked that this is the same error message for a nonsense plugin name, so I expect that it has to do with not finding affinder because make_viewer_widget avoids importing plugins.
