### PR TITLE
aligning non-image layers

### DIFF
--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -90,8 +90,8 @@ def close_affinder(layers, callback):
         )
 def start_affinder(
         viewer: 'napari.viewer.Viewer',
-        reference: 'napari.layers.Image',
-        moving: 'napari.layers.Image',
+        reference: 'napari.layers.Layer',
+        moving: 'napari.layers.Layer',
         model: AffineTransformChoices,
         output: Optional[pathlib.Path] = None,
         ):


### PR DESCRIPTION
This PR should address #42 @jni 

I just changed two lines - converting the input layer types to the more general `napari.layers.Layer` instead of `napari.layers.Image`. It seems to have worked.

Image to shape affine transform
https://user-images.githubusercontent.com/54516770/151113341-4f5185e9-ba83-4344-961b-04d29346c14f.mp4

Image to image transform (is preserved)
https://user-images.githubusercontent.com/54516770/151113418-b21b5c1d-27b6-4c74-aea4-c9353140cdd9.mp4


Note that I'm not actually trying to match anything in these examples! So they look weird. But the affine makes the expected distortions to the moving image.