### PR TITLE
add existing points layer

### DIFF
--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -91,9 +91,9 @@ def close_affinder(layers, callback):
 def start_affinder(
         viewer: 'napari.viewer.Viewer',
         reference: 'napari.layers.Layer',
-        reference_pts: 'napari.layers.Points',
+        reference_points: 'napari.layers.Points',
         moving: 'napari.layers.Layer',
-        moving_pts: 'napari.layers.Points',
+        moving_points: 'napari.layers.Points',
         model: AffineTransformChoices,
         output: Optional[pathlib.Path] = None,
         ):
@@ -103,7 +103,7 @@ def start_affinder(
         # focus on the reference layer
         reset_view(viewer, reference)
         # set points layer for each image
-        points_layers = [reference_pts, moving_pts]
+        points_layers = [reference_points, moving_points]
         # Use C0 and C1 from matplotlib color cycle
         points_layers_to_add = [(reference, (0.122, 0.467, 0.706, 1.0)),
                                 (moving, (1.0, 0.498, 0.055, 1.0))]

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -90,8 +90,8 @@ def close_affinder(layers, callback):
         )
 def start_affinder(
         viewer: 'napari.viewer.Viewer',
-        reference: 'napari.layers.Image',
-        moving: 'napari.layers.Image',
+        reference: 'napari.layers.Layer',
+        moving: 'napari.layers.Layer',
         model: AffineTransformChoices,
         output: Optional[pathlib.Path] = None,
         ):

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -93,6 +93,8 @@ def start_affinder(
         reference: 'napari.layers.Layer',
         moving: 'napari.layers.Layer',
         model: AffineTransformChoices,
+        reference_pts: Optional['napari.layers.Points'] = None,
+        moving_pts: Optional['napari.layers.Points'] = None,
         output: Optional[pathlib.Path] = None,
         ):
     mode = start_affinder._call_button.text  # can be "Start" or "Finish"
@@ -103,10 +105,12 @@ def start_affinder(
         # make a points layer for each image
         points_layers = []
         # Use C0 and C1 from matplotlib color cycle
-        for layer, color in [
-                (reference, (0.122, 0.467, 0.706, 1.0)),
-                (moving, (1.0, 0.498, 0.055, 1.0)),
-                ]:
+        points_layers_to_add = []
+        if reference_pts is None:
+            points_layers_to_add.append((reference, (0.122, 0.467, 0.706, 1.0)))
+        if moving_pts is None:
+            points_layers_to_add.append((moving, (1.0, 0.498, 0.055, 1.0)))
+        for layer, color in points_layers_to_add:
             new_layer = viewer.add_points(
                     ndim=layer.ndim,
                     name=layer.name + '_pts',

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -91,10 +91,10 @@ def close_affinder(layers, callback):
 def start_affinder(
         viewer: 'napari.viewer.Viewer',
         reference: 'napari.layers.Layer',
+        reference_pts: 'napari.layers.Points',
         moving: 'napari.layers.Layer',
+        moving_pts: 'napari.layers.Points',
         model: AffineTransformChoices,
-        reference_pts: Optional['napari.layers.Points'] = None,
-        moving_pts: Optional['napari.layers.Points'] = None,
         output: Optional[pathlib.Path] = None,
         ):
     mode = start_affinder._call_button.text  # can be "Start" or "Finish"
@@ -102,23 +102,23 @@ def start_affinder(
     if mode == 'Start':
         # focus on the reference layer
         reset_view(viewer, reference)
-        # make a points layer for each image
-        points_layers = []
+        # set points layer for each image
+        points_layers = [reference_pts, moving_pts]
         # Use C0 and C1 from matplotlib color cycle
-        points_layers_to_add = []
-        if reference_pts is None:
-            points_layers_to_add.append((reference, (0.122, 0.467, 0.706, 1.0)))
-        if moving_pts is None:
-            points_layers_to_add.append((moving, (1.0, 0.498, 0.055, 1.0)))
-        for layer, color in points_layers_to_add:
-            new_layer = viewer.add_points(
+        points_layers_to_add = [(reference, (0.122, 0.467, 0.706, 1.0)),
+                                (moving, (1.0, 0.498, 0.055, 1.0))]
+        # make points layer if it was not specified
+        for i in range(len(points_layers)):
+            if points_layers[i] is None:
+                layer, color = points_layers_to_add[i]
+                new_layer = viewer.add_points(
                     ndim=layer.ndim,
                     name=layer.name + '_pts',
                     affine=layer.affine,
                     face_color=[color],
                     )
-            points_layers.append(new_layer)
-        pts_layer0 = points_layers[0]
+                points_layers[i] = new_layer
+        pts_layer0 = points_layers[0]####
         pts_layer1 = points_layers[1]
 
         # make a callback for points added


### PR DESCRIPTION
This PR tries to solve #11 but is very inelegant. 

It doesn't seem magicgui has implemented `Optional` for napari layers so instead I added two compulsory layer points `reference_pts` and `moving_pts`.

Case 1: When there are no points layers on the screen, no reference and moving points layers can be selected. Affinder functions like normal.
https://user-images.githubusercontent.com/54516770/151280006-b8ac697a-5999-4e92-9591-c030ba0ca8f7.mp4

Case 2a: When points layers are present on the screen, reference and moving pts layers must be specified. Affinder will then add existing points to these layers.
https://user-images.githubusercontent.com/54516770/151280118-08528c6f-9bce-4621-9757-12ad4a372cdf.mp4

Case 2b: If the user has points layers on the screen but does not want to use any of them in affinder (i.e. they'd like to start new points layers), they would need to manually add empty points layers and specify them in the reference and moving pts dropdowns (this is what the Optional magicgui support would have prevented).
https://user-images.githubusercontent.com/54516770/151280461-2c01de19-5c47-447f-8827-8651cb7d6058.mp4

I'm not sure how urgently we want this feature or if we're happy to wait for whenever magicgui figures out how to handle `Optional[napari.layers.Layer]` type declarations. If we do want it, I will add documentation in the readme letting people know about the three cases above.

