### PR TITLE
Run tox under GabrielBB action which seems to be more stable

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -33,8 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
+      # these libraries enable testing on Qt on linux
       - name: Install Linux libraries
         if: runner.os == 'Linux'
         run: |
@@ -61,7 +60,9 @@ jobs:
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        run: tox
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: tox
         env:
           PLATFORM: ${{ matrix.platform }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ passenv =
 deps = 
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
-    pytest-xvfb ; sys_platform == 'linux'
     pytest-qt
     scikit-image[data]
     napari[pyqt5]


### PR DESCRIPTION
@DragaDoncila has suggested running tox this way to avoid the sporadic segmentation faults on CI.