### PR TITLE
Only run napari-hub preview on adding hub-preview label

### DIFF
--- a/.github/workflows/plugin_preview.yml
+++ b/.github/workflows/plugin_preview.yml
@@ -4,12 +4,14 @@ name: napari hub Preview Page # we use this name to find your preview page artif
 
 on:
   pull_request:
-    branches:
-      - '**'
+    types: [labeled]
+  workflow_dispatch:
 
 jobs:
   preview-page:
     name: Preview Page Deploy
+
+    if: ${{ github.event.label.name == 'hub-preview' && github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The preview bot can be very distracting when commenting on every push, even on PRs that have nothing to do with the hub. This instead runs it when the label 'hub-preview' is added, or when the workflow is manually triggered for the PR.

See also chanzuckerberg/napari-hub#449.
