### PR TITLE
Add documentation link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,15 @@
 
 Quickly find the affine matrix mapping one image to another using manual correspondence points annotation
 
-----------------------------------
-
-This [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.
-
-<!--
-Don't miss the full getting started guide to set up your new package:
-https://github.com/napari/cookiecutter-napari-plugin#getting-started
-
-and review the napari docs for plugin developers:
-https://napari.org/docs/plugins/index.html
--->
-
 ## Installation
 
 You can install `affinder` via [pip]:
 
     pip install affinder
+
+## Documentation
+
+The affinder documentation is available here: [https://jni.github.io/affinder/](https://jni.github.io/affinder/)
 
 ## Contributing
 
@@ -55,3 +47,15 @@ If you encounter any problems, please [file an issue] along with a detailed desc
 [tox]: https://tox.readthedocs.io/en/latest/
 [pip]: https://pypi.org/project/pip/
 [PyPI]: https://pypi.org/
+
+----------------------------------
+
+This [napari] plugin was generated with [Cookiecutter] using with [@napari]'s [cookiecutter-napari-plugin] template.
+
+<!--
+Don't miss the full getting started guide to set up your new package:
+https://github.com/napari/cookiecutter-napari-plugin#getting-started
+
+and review the napari docs for plugin developers:
+https://napari.org/docs/plugins/index.html
+-->


### PR DESCRIPTION
Add link to documentation at https://jni.github.io/affinder/

The gh-pages docs don't pop up for me in a google search for affinder, whereas the github repo is easy to find.

This makes it too easy to assume that there are no docs, which is a shame given all the hard work James put into PR https://github.com/jni/affinder/pull/53