### PR TITLE
Ensure reference and moving layers are different

### DIFF
--- a/src/affinder/_tests/test_affinder.py
+++ b/src/affinder/_tests/test_affinder.py
@@ -83,3 +83,18 @@ def test_layer_types(make_napari_viewer, tmp_path, reference, moving):
                                 [0., 0., 1.]])
 
     np.testing.assert_allclose(actual_affine, expected_affine)
+
+
+def test_ensure_different_layers(make_napari_viewer):
+    viewer = make_napari_viewer()
+    image0 = np.random.random((50, 50))
+    image1 = np.random.random((30, 30))
+    image2 = np.random.random((40, 40))
+    for image in [image0, image1, image2]:
+        viewer.add_image(image)
+    qtwidget, widget = viewer.window.add_plugin_dock_widget(
+            'affinder', 'Start affinder'
+            )
+    assert widget.reference.value != widget.moving.value
+    widget.reference.value = widget.moving.value
+    assert widget.reference.value != widget.moving.value

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -100,7 +100,7 @@ def _update_unique_choices(widget, choice_name):
     index = choice_names.index(choice_name)
     value = widget.choices[index]
     if widget.value is value:
-        next_index = (index + 1) % len(choices)
+        next_index = (index+1) % len(choices)
         widget.changed.block()
         # should block() be a context manager?
         widget.value = widget.choices[next_index]


### PR DESCRIPTION
Using the default ComboBox widget, initially, the selected reference and moving
layers are the same layer (the first layer in the layer list). This means that
if the user is not very careful, they will be aligning that layer to itself,
which is confusing behaviour in affinder. It's also poor default behaviour.

With this PR, a callback is created in selecting a layer in either ComboBox
ensures that the other ComboBox contains a different layer.

With great thanks to @tlambert03 for excellent docs at:

https://pyapp-kit.github.io/magicgui/events/#connecting-to-events

particularly for including the magic_factory tab. 😃
