### PR TITLE
Use signal blocked context manager

### DIFF
--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -101,10 +101,8 @@ def _update_unique_choices(widget, choice_name):
     value = widget.choices[index]
     if widget.value is value:
         next_index = (index+1) % len(choices)
-        widget.changed.block()
-        # should block() be a context manager?
-        widget.value = widget.choices[next_index]
-        widget.changed.unblock()
+        with widget.changed.blocked():
+            widget.value = widget.choices[next_index]
 
 
 def _on_affinder_main_init(widget):


### PR DESCRIPTION
The blocked() method on a psygnal event returns a context manager, which is the
most appropriate thing to use in this case.
