### PR TITLE
Fix metadata of new layer after applying transform

### DIFF
--- a/src/affinder/apply_tf.py
+++ b/src/affinder/apply_tf.py
@@ -91,7 +91,7 @@ def apply_affine(
     layertype = 'image'
     ref_metadata = {
             n: getattr(reference_layer, n)
-            for n in ['scale', 'translate', 'rotate', 'shear']
+            for n in ['scale', 'translate', 'rotate', 'shear', 'affine']
             }
     mov_metadata = moving_layer.as_layer_data_tuple()[1]
     name = {'name': moving_layer.name + '_transformed'}


### PR DESCRIPTION
The new layer was still being displayed with the moving layer's affine. 
Corrected this to the reference layer's affine to fix the display problem.

I had some confusions getting my original apply_transform branch up to date. In the end I created a new branch for this ...