### PR TITLE
Add txt file filter for saving output file

### DIFF
--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -129,7 +129,7 @@ def _on_affinder_main_init(widget):
         widget_init=_on_affinder_main_init,
         call_button='Start',
         layout='vertical',
-        output={'mode': 'w'},
+        output={'mode': 'w', 'label': 'Save transformation as', 'filter': '*.txt'},
         viewer={'visible': False, 'label': ' '},
         delete_pts={
                 'label':

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -208,7 +208,6 @@ def start_affinder(
         if delete_pts:
             start_affinder.remove_points_layers()
         start_affinder._call_button.text = 'Start'
-        start_affinder.output = None
 
 
 def calculate_transform(src, dst, model_class=AffineTransform):

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -208,6 +208,7 @@ def start_affinder(
         if delete_pts:
             start_affinder.remove_points_layers()
         start_affinder._call_button.text = 'Start'
+        start_affinder.output = None
 
 
 def calculate_transform(src, dst, model_class=AffineTransform):


### PR DESCRIPTION
Closes #89, preventing images from being overwritten by the affine parameters, by:

- changing the label of the file selection box to make it clearer that it's for saving affine parameters, and
- adding a file filter to the file selection widget, so it only shows .txt files.