### PR TITLE
Update tests to fix napari 0.4.19 errors

### DIFF
--- a/src/affinder/_tests/test_affinder.py
+++ b/src/affinder/_tests/test_affinder.py
@@ -60,8 +60,10 @@ def test_layer_types(make_napari_viewer, tmp_path, reference, moving):
 
     viewer = make_napari_viewer()
 
-    l0 = viewer.add_layer(reference, name='layer0')
-    l1 = viewer.add_layer(moving, name='layer1')
+    l0 = viewer.add_layer(reference)
+    l0.name = 'layer0'
+    l1 = viewer.add_layer(moving)
+    l1.name = 'layer1'
 
     my_widget_factory = start_affinder()
     my_widget_factory(

--- a/src/affinder/_tests/test_affinder.py
+++ b/src/affinder/_tests/test_affinder.py
@@ -60,13 +60,8 @@ def test_layer_types(make_napari_viewer, tmp_path, reference, moving):
 
     viewer = make_napari_viewer()
 
-    l0 = viewer.add_layer(reference)
-    viewer.layers[-1].name = "layer0"
-    viewer.layers[-1].colormap = "green"
-
-    l1 = viewer.add_layer(moving)
-    viewer.layers[-1].name = "layer1"
-    viewer.layers[-1].colormap = "magenta"
+    l0 = viewer.add_layer(reference, name='layer0')
+    l1 = viewer.add_layer(moving, name='layer1')
 
     my_widget_factory = start_affinder()
     my_widget_factory(


### PR DESCRIPTION
Setting the colormap to 'green' wasn't expected to work for all layer types,
and is unnecessary in testing anyway.
