### PR TITLE
Restore missed points affine setting in callback

### DIFF
--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -84,6 +84,9 @@ def next_layer_callback(
                 moving_image_layer.affine = convert_affine_to_ndims(
                         (ref_mat @ mat.params), moving_image_layer.ndim
                         )
+                moving_points_layer.affine = convert_affine_to_ndims(
+                        (ref_mat @ mat.params), moving_image_layer.ndim
+                        )
                 if output is not None:
                     np.savetxt(output, np.asarray(mat.params), delimiter=',')
             viewer.layers.selection.active = reference_points_layer


### PR DESCRIPTION
In #58, we forgot to also propagate the affine transformation to the moving
points layer. This PR fixes that.
