### PR TITLE
Add nap6 menu contributions

### DIFF
--- a/src/affinder/napari.yaml
+++ b/src/affinder/napari.yaml
@@ -25,3 +25,10 @@ contributions:
     display_name: Apply affine
   - command: affinder.load_affine
     display_name: Load affine
+  menus:
+    napari/layers/register:
+    - command: affinder.start_affinder
+    napari/layers/transform:
+    - command: affinder.copy_affine
+    - command: affinder.apply_affine
+    - command: affinder.load_affine


### PR DESCRIPTION
This PR places the affinder widgets in defined menus in napari>=0.5.0.

See NAP-6 for details:

https://napari.org/dev/naps/6-contributable-menus.html

Result (needs napari/napari#7011):

<img width="322" alt="Screenshot 2024-06-26 at 2 50 42 PM" src="https://github.com/jni/affinder/assets/492549/75ec7ac3-4634-4d74-aacf-b7d897dab266"> <img width="340" alt="Screenshot 2024-06-26 at 2 50 51 PM" src="https://github.com/jni/affinder/assets/492549/e10ec578-da16-4fcf-8ea0-202f8771ce1f">