### PR TITLE
Add option to click corresponding points in a pairwise fashion before transform is first estimated

### DIFF
--- a/src/affinder/_tests/test_affinder.py
+++ b/src/affinder/_tests/test_affinder.py
@@ -1,5 +1,5 @@
 from affinder import start_affinder, copy_affine, apply_affine, load_affine
-from affinder.affinder import AffineTransformChoices
+from affinder.affinder import AffineTransformChoices, InitialPointAnnotationModeChoices
 from skimage import data, transform
 import numpy as np
 from itertools import product
@@ -296,10 +296,11 @@ def test_remove_points_layers(remove_pts, make_napari_viewer):
 
 
 @pytest.mark.parametrize(
-        "pairwise_mode",
-        [True, False]
+        "initial_point_annotation_mode",
+        [InitialPointAnnotationModeChoices.alternating,
+        InitialPointAnnotationModeChoices.grouped_by_layer]
         )
-def test_clicking_flow(make_napari_viewer, tmp_path, pairwise_mode):
+def test_clicking_flow(make_napari_viewer, tmp_path, initial_point_annotation_mode):
     """
     Test clicking flow:
     In pairwise mode, adding points to the
@@ -322,7 +323,7 @@ def test_clicking_flow(make_napari_viewer, tmp_path, pairwise_mode):
             reference=l0,
             moving=l1,
             output=tmp_path / 'my_affine.txt',
-            pairwise_mode=pairwise_mode,
+            initial_point_annotation_mode=initial_point_annotation_mode,
             )
 
     for i in range(8):
@@ -332,7 +333,8 @@ def test_clicking_flow(make_napari_viewer, tmp_path, pairwise_mode):
                 [active_layer_before_click.data, np.random.random((1, 2))]
                 )
         # Check automated layer switching is working as expected
-        if pairwise_mode or i in [2, 5] + [6, 7]:
+        if initial_point_annotation_mode == InitialPointAnnotationModeChoices.alternating or\
+            i in [2, 5] + [6, 7]:
             assert viewer.layers.selection.active != active_layer_before_click
         else:
             assert viewer.layers.selection.active == active_layer_before_click

--- a/src/affinder/_tests/test_affinder.py
+++ b/src/affinder/_tests/test_affinder.py
@@ -293,3 +293,46 @@ def test_remove_points_layers(remove_pts, make_napari_viewer):
             pt_layer in viewer.layers
             for pt_layer in ['ref_im_pts', 'mov_im_pts']
             )
+
+
+@pytest.mark.parametrize(
+        "pairwise_mode",
+        [True, False]
+        )
+def test_clicking_flow(make_napari_viewer, tmp_path, pairwise_mode):
+    """
+    Test clicking flow:
+    In pairwise mode, adding points to the
+    reference should switch to the moving layer, and vice versa.
+    In non-pairwise mode, clicking on the reference layer should
+    not switch to the moving layer until the user has added ndim+1 points.
+    """
+
+    viewer = make_napari_viewer()
+
+    l0 = viewer.add_layer(layers2d[0])
+    l0.name = "layer0"
+
+    l1 = viewer.add_layer(layers2d_transformed[0])
+    l1.name = 'layer1'
+
+    affinder_widget = start_affinder()
+    affinder_widget(
+            viewer=viewer,
+            reference=l0,
+            moving=l1,
+            output=tmp_path / 'my_affine.txt',
+            pairwise_mode=pairwise_mode,
+            )
+
+    for i in range(8):
+        # Simulate clicking on a point on the currently active layer
+        active_layer_before_click = viewer.layers.selection.active
+        active_layer_before_click.data = np.concatenate(
+                [active_layer_before_click.data, np.random.random((1, 2))]
+                )
+        # Check automated layer switching is working as expected
+        if pairwise_mode or i in [2, 5] + [6, 7]:
+            assert viewer.layers.selection.active != active_layer_before_click
+        else:
+            assert viewer.layers.selection.active == active_layer_before_click

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -51,13 +51,14 @@ def next_layer_callback(
         moving_image_layer,
         moving_points_layer,
         model_class,
-        output
+        output,
+        pairwise_mode=False,
         ):
     pts0, pts1 = reference_points_layer.data, moving_points_layer.data
     n0, n1 = len(pts0), len(pts1)
     ndim = pts0.shape[1]
     if reference_points_layer in viewer.layers.selection:
-        if n0 < ndim + 1:
+        if not pairwise_mode and n0 < ndim + 1:
             return
         if n0 == ndim + 1:
             reset_view(viewer, moving_image_layer)
@@ -175,6 +176,14 @@ def _on_affinder_main_init(widget):
                         'will be deleted when clicking "Finish".'
                         ),
                 },
+        pairwise_mode={
+                'label': 'Pairwise point addition mode',
+                'tooltip': (
+                        'If ticked, the user adds points in a pairwise fashion, i.e. one point\n'
+                        'for the reference, one for the moving, one for the reference etc.\n'
+                        'Otherwise, the user adds ndim + 1 points to the reference and\n'
+                        'subsequently the same number of points to the moving layer.'),
+                },
         )
 def start_affinder(
         viewer: 'napari.viewer.Viewer',
@@ -188,6 +197,7 @@ def start_affinder(
         delete_pts: bool = False,
         min_point_size: int = 20,
         max_point_size: int = 40,
+        pairwise_mode: bool = False,
         ):
     mode = start_affinder._call_button.text  # can be "Start" or "Finish"
 
@@ -227,7 +237,8 @@ def start_affinder(
                 moving_image_layer=moving,
                 moving_points_layer=pts_layer1,
                 model_class=model.value,
-                output=output
+                output=output,
+                pairwise_mode=pairwise_mode
                 )
         pts_layer0.events.data.connect(callback)
         pts_layer1.events.data.connect(callback)

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -25,6 +25,11 @@ class AffineTransformChoices(Enum):
     similarity = SimilarityTransform
 
 
+class InitialPointAnnotationModeChoices(Enum):
+    alternating = 'alternating'
+    grouped_by_layer = 'grouped_by_layer'
+
+
 def reset_view(viewer: 'napari.Viewer', layer: 'napari.layers.Layer'):
     if viewer.dims.ndisplay != 2:
         return
@@ -52,13 +57,13 @@ def next_layer_callback(
         moving_points_layer,
         model_class,
         output,
-        pairwise_mode=False,
+        initial_point_annotation_mode,
         ):
     pts0, pts1 = reference_points_layer.data, moving_points_layer.data
     n0, n1 = len(pts0), len(pts1)
     ndim = pts0.shape[1]
     if reference_points_layer in viewer.layers.selection:
-        if not pairwise_mode and n0 < ndim + 1:
+        if initial_point_annotation_mode == InitialPointAnnotationModeChoices.grouped_by_layer and n0 < ndim + 1:
             return
         if n0 == ndim + 1:
             reset_view(viewer, moving_image_layer)
@@ -176,13 +181,15 @@ def _on_affinder_main_init(widget):
                         'will be deleted when clicking "Finish".'
                         ),
                 },
-        pairwise_mode={
-                'label': 'Pairwise point addition mode',
+        initial_point_annotation_mode={
+                'label': 'Initial point annotation',
                 'tooltip': (
-                        'If ticked, the user adds points in a pairwise fashion, i.e. one point\n'
-                        'for the reference, one for the moving, one for the reference etc.\n'
-                        'Otherwise, the user adds ndim + 1 points to the reference and\n'
-                        'subsequently the same number of points to the moving layer.'),
+                        'Before affinder can have an initial transform estimate, it needs'
+                        'ndim + 1 points to match between reference and moving layers. '
+                        'In alternating mode, you pick one point in reference, then its '
+                        'corresponding point in moving, and so on. In grouped mode, you '
+                        'first pick ndim + 1 points in the reference layer, then ndim + 1'
+                        'in the moving layer in the same order, before alternating.'),
                 },
         )
 def start_affinder(
@@ -197,7 +204,7 @@ def start_affinder(
         delete_pts: bool = False,
         min_point_size: int = 20,
         max_point_size: int = 40,
-        pairwise_mode: bool = False,
+        initial_point_annotation_mode: InitialPointAnnotationModeChoices = InitialPointAnnotationModeChoices.grouped_by_layer,
         ):
     mode = start_affinder._call_button.text  # can be "Start" or "Finish"
 
@@ -238,7 +245,7 @@ def start_affinder(
                 moving_points_layer=pts_layer1,
                 model_class=model.value,
                 output=output,
-                pairwise_mode=pairwise_mode
+                initial_point_annotation_mode=initial_point_annotation_mode
                 )
         pts_layer0.events.data.connect(callback)
         pts_layer1.events.data.connect(callback)

--- a/src/affinder/affinder.py
+++ b/src/affinder/affinder.py
@@ -26,8 +26,8 @@ class AffineTransformChoices(Enum):
 
 
 class InitialPointAnnotationModeChoices(Enum):
-    alternating = 'alternating'
     grouped_by_layer = 'grouped_by_layer'
+    alternating = 'alternating'
 
 
 def reset_view(viewer: 'napari.Viewer', layer: 'napari.layers.Layer'):


### PR DESCRIPTION
Implements the proposed pairwise clicking mode detailed in https://github.com/jni/affinder/issues/100:

> Would it be an option to consider including a mode in which points are added in a pairwise fashion? We were thinking this would not necessarily need to change the current clicking flow but could be an option provided in an additional drop-down menu. Optionally, there could be a notification showing up how many more points are required before the transform can be estimated.

Let me know what you think @jni! Happy to include any changes / improvements.

Screenshot:
<img width="1085" alt="image" src="https://github.com/user-attachments/assets/23ab177e-6235-4dd2-ad0b-9265ea58809e" />

### Update

After incorporating @jni's improvements and at the final state of the PR the plugin looks like this:

<img width="1147" height="642" alt="image" src="https://github.com/user-attachments/assets/1b3a2761-088f-4675-a91f-fa9fbca934f3" />
